### PR TITLE
SPI bus release on multiple init call

### DIFF
--- a/main/epdif.cpp
+++ b/main/epdif.cpp
@@ -65,6 +65,13 @@ void EpdIf::SpiTransfer(unsigned char data) {
 }
 
 int EpdIf::IfInit(void) {
+
+    if(spi) {
+		spi_bus_remove_device(spi);
+	}
+
+	spi_bus_free(VSPI_HOST);
+
     gpio_config_t io_conf;
     io_conf.intr_type = GPIO_INTR_DISABLE;
     io_conf.mode = GPIO_MODE_OUTPUT;


### PR DESCRIPTION
Now you can call init on the epd object multiple times passing a different lut value (complete, partial).
This can be useful to clean the display in full mode once in a while
